### PR TITLE
Fixed the List of appointments in `app/calendar`

### DIFF
--- a/client/src/pages/Calendar.svelte
+++ b/client/src/pages/Calendar.svelte
@@ -1,8 +1,15 @@
 <script>
     import { get, post, del } from "../util";
+
+    let schedules;
+    async function loadSchedules() {
+        schedules = await get("/schedules");
+    }
 </script>
 
-{#await get("/schedules") then schedules}
+{#await loadSchedules()}
+    <p>Caricamento...</p>
+{:then}
     {#each schedules as sched}
         <div class="p-2">
             <div
@@ -10,7 +17,7 @@
             >
                 <div class="card-body">
                     <h1>
-                        Appuntamento con <br />{sched.paziente}
+                        Appuntamento con <br />{sched.paziente.nome} {sched.paziente.cognome}
                     </h1>
                     <div class="justify-end card-actions">
                         <a href="/app/conference?roomId=theRoom&peerId=doctor" class="btn btn-primary">

--- a/client/src/pages/Calendar.svelte
+++ b/client/src/pages/Calendar.svelte
@@ -1,15 +1,11 @@
 <script>
     import { get, post, del } from "../util";
 
-    let schedules;
-    async function loadSchedules() {
-        schedules = await get("/schedules");
-    }
 </script>
 
-{#await loadSchedules()}
+{#await get("/schedules")}
     <p>Caricamento...</p>
-{:then}
+{:then schedules}
     {#each schedules as sched}
         <div class="p-2">
             <div

--- a/client/src/pages/Calendar.svelte
+++ b/client/src/pages/Calendar.svelte
@@ -17,7 +17,7 @@
             >
                 <div class="card-body">
                     <h1>
-                        Appuntamento con <br />{sched.paziente?.nome} {sched.paziente?.cognome}
+                        Appuntamento con <br />{sched.paziente?.nome ?? "Nome"} {sched.paziente?.cognome ?? "Cognome"}
                     </h1>
                     <div class="justify-end card-actions">
                         <a href="/app/conference?roomId=theRoom&peerId=doctor" class="btn btn-primary">

--- a/client/src/pages/Calendar.svelte
+++ b/client/src/pages/Calendar.svelte
@@ -17,7 +17,7 @@
             >
                 <div class="card-body">
                     <h1>
-                        Appuntamento con <br />{sched.paziente.nome} {sched.paziente.cognome}
+                        Appuntamento con <br />{sched.paziente?.nome} {sched.paziente?.cognome}
                     </h1>
                     <div class="justify-end card-actions">
                         <a href="/app/conference?roomId=theRoom&peerId=doctor" class="btn btn-primary">


### PR DESCRIPTION
Solves #40.

Saving all the user's info in our DB when scheduling an appointment makes sense: it allows the reading all of its properties in other pages (e.g. name, surname, ssn, phone, email, etc.).

Since now we're saving the whole patient into the database, the `app/calendar` page now needs to read the object properties such as `name` and `surname`.

Since our dev DB contains older documents without a full `patient` object, I've implemented a null safe version of this page. This could be a common practice in the near future.