### PR TITLE
Improved the starting configuration and the conf samples

### DIFF
--- a/openmed.dev.sample
+++ b/openmed.dev.sample
@@ -3,8 +3,11 @@
     "publicPort": 1024,
     "publicIp": "127.0.0.1",
     "mongodbUrl": "mongodb://localhost/openmed",
-    "gmailUsername": "",
-    "gmailPassword": "",
+    "mailer": {
+        "provider": "google",
+        "username": "",
+        "password": ""
+    },
     "sslCert": "",
     "sslKey": "",
     "rtcMinPort": 30000,

--- a/openmed.prod.sample
+++ b/openmed.prod.sample
@@ -3,10 +3,16 @@
     "publicPort": 443,
     "publicIp": "<your-public-ip>",
     "mongodbUrl": "mongodb://<your-mongo-username>:<your-mongo-password>@<your-mongo-host-name>:27017/<your-mongo-database-name>",
-    "gmailUsername": "<your-gmail-address>",
-    "gmailPassword": "<your-gmail-app-password>",
+    "mailConfig": {
+        "provider": "<your-provider>",
+        "smtp": "<smtp-host-address-if-any>",
+        "port": "<smtp-port-if-any>",
+        "username": "<your-email-address>",
+        "password": "<your-password>"
+    },
     "sslCert": "/etc/letsencrypt/live/<your-host-name>/fullchain.pem",
     "sslKey": "/etc/letsencrypt/live/<your-hostname-name>/privkey.pem",
     "rtcMinPort": 30000,
     "rtcMaxPort": 39999
 }
+

--- a/server/config.js
+++ b/server/config.js
@@ -10,19 +10,29 @@
 const config = require("../openmed.json")
 const os = require('os');
 
-const gmailMailer = {
-	service: 'gmail',
+const gmailMailer =
+	config.mailConfig?.provider === "google"
+		? {
+			service: 'gmail',
+			auth: {
+				user: config?.mailConfig?.username,
+				pass: config?.mailConfig?.password,
+			}
+		}
+		: null;
+
+const otherMailer = {
+	streamTransport: true,
+	service: config.mailConfig.provider,
+	host: config.mailConfig.smtp,
+	port: config.mailConfig?.port ?? 25,
 	auth: {
-		user: config.gmailUsername,
-		pass: config.gmailPassword
-	}
+		user: config.mailConfig.username,
+		pass: config.mailConfig.password,
+	},
 }
 
-const streamMailer = {
-	streamTransport: true
-}
-
-const mailer = config.gmailUsername == "" ? streamMailer : gmailMailer
+const mailer = gmailMailer ?? otherMailer;
 
 module.exports =
 {  


### PR DESCRIPTION
As the title states: it is now possible to configure via `openmed.json` our personal SMTP settings.

The new `.sample` files reflect these changes.